### PR TITLE
VEGA-2834: Отключение кэширования для канвас элементов

### DIFF
--- a/src/redux-store/logic-constructor/actions.ts
+++ b/src/redux-store/logic-constructor/actions.ts
@@ -246,6 +246,7 @@ const fetchCanvasItemsData = (): ThunkAction<void, StoreLC, unknown, AnyAction> 
   vegaApi
     .query({
       query: FETCH_CANVAS_ITEMS_DATA,
+      fetchPolicy: 'network-only',
     })
     .then(async (response) => {
       if (response.networkStatus === NetworkStatus.ready) {


### PR DESCRIPTION
Jira issue: VEGA-2834
https://jira.konakov.tv/browse/VEGA-2834

- Убрал кэширование запроса по канвас элементам

## Чек-лист

- [ ] Назначен исполнитель PR
- [ ] eslint/stylelint и dev-консоль браузера без ошибок
- [ ] Написаны тесты или заведена задача на покрытие тестами

## Дополнительно

- [ ] проверять все разрешения, когда меняется верстка
- [ ] Указан `no_test` лейбл в задаче, если не требуется тестирование QA
- [ ] В задаче описано, как тестировать изменения (если это нужно)
