### PR TITLE
[VEGA-2956] fix(flow): Возможность добавить сразу несколько обьектов в шаг

### DIFF
--- a/src/redux-store/logic-constructor/actions.ts
+++ b/src/redux-store/logic-constructor/actions.ts
@@ -379,6 +379,9 @@ const addProjectStructureObjectToCanvasElement = (
 
     if (treeData?.stepData) {
       const { stepData: existStepData } = treeData;
+      const existObjectsIds = existStepData.events[0]?.content.map((item) => item.id) || [];
+
+      if (draggingElements.length === 1 && existObjectsIds.includes(draggingElements[0].id)) return;
 
       const draggingElementsIds = draggingElements.map((el: TargetData) => el.id);
       const newObjectsIds = composeDomainObjectsArray(draggingElementsIds, nodeList)?.map(
@@ -386,8 +389,6 @@ const addProjectStructureObjectToCanvasElement = (
       );
 
       if (!newObjectsIds) return; // TODO: process error
-
-      const existObjectsIds = existStepData.events[0]?.content.map((item) => item.id) || [];
 
       const resultIdsArray = clearArrayFromDuplicates([...existObjectsIds, ...newObjectsIds]);
 

--- a/src/redux-store/logic-constructor/actions.ts
+++ b/src/redux-store/logic-constructor/actions.ts
@@ -16,8 +16,8 @@ import { FETCH_CANVAS_ITEMS_DATA } from './queries';
 
 import { setIsDroppingOnExistingStep } from '@/redux-store/activities/actions';
 import {
-  CanvasElements,
   CanvasElement,
+  CanvasElements,
   CanvasViewEntity,
   Step,
   StepData,

--- a/src/utils/clear-array-from-duplicates.ts
+++ b/src/utils/clear-array-from-duplicates.ts
@@ -1,0 +1,3 @@
+export const clearArrayFromDuplicates = <T>(array: T[]): T[] => {
+  return Array.from(new Set(array));
+};

--- a/src/utils/compose-domain-objects-array.ts
+++ b/src/utils/compose-domain-objects-array.ts
@@ -4,19 +4,19 @@ import { Content as DomainObject } from '@/types/redux-store';
 import { getTreeNodeById } from '@/utils/get-tree-node-by-id';
 
 export const composeDomainObjectsArray = (ids: string[], source: TreeItem[]): DomainObject[] => {
-  const domainObjects: DomainObject[] = [];
-
-  ids.forEach((id) => {
+  return ids.reduce((acc: DomainObject[], id) => {
     const treeNode = getTreeNodeById(id, source);
 
     if (treeNode) {
-      domainObjects.push({
+      acc.push({
         id: treeNode.id,
         name: treeNode.name,
         type: 'domain',
       });
-    }
-  });
 
-  return domainObjects;
+      return acc;
+    }
+
+    return acc;
+  }, []);
 };

--- a/src/utils/compose-domain-objects-array.ts
+++ b/src/utils/compose-domain-objects-array.ts
@@ -1,0 +1,22 @@
+import { TreeItem } from '@gpn-prototypes/vega-ui';
+
+import { Content as DomainObject } from '@/types/redux-store';
+import { getTreeNodeById } from '@/utils/get-tree-node-by-id';
+
+export const composeDomainObjectsArray = (ids: string[], source: TreeItem[]): DomainObject[] => {
+  const domainObjects: DomainObject[] = [];
+
+  ids.forEach((id) => {
+    const treeNode = getTreeNodeById(id, source);
+
+    if (treeNode) {
+      domainObjects.push({
+        id: treeNode.id,
+        name: treeNode.name,
+        type: 'domain',
+      });
+    }
+  });
+
+  return domainObjects;
+};

--- a/src/utils/compose-domain-objects-array.ts
+++ b/src/utils/compose-domain-objects-array.ts
@@ -13,8 +13,6 @@ export const composeDomainObjectsArray = (ids: string[], source: TreeItem[]): Do
         name: treeNode.name,
         type: 'domain',
       });
-
-      return acc;
     }
 
     return acc;


### PR DESCRIPTION
## Задача
Задача в Jira: https://jira.konakov.tv/browse/VEGA-2956
Ссылка на стенд: https://VEGA-2956.vega-2.csssr.cloud
Jira issue: VEGA-2956

Дополнительно:
- Добавлена логика удаления дубликатов объектов из шага

ВАЖНО! 
По группировке объектов в КЛ необходимы уточнения. При перемещении объекта из структуры проекта на канвас, структура меняется. Необходимо уточнить валидное отображение.

и

Необходимо исправление курсора с "запретом" при перетаскивании недублирующихся элементов на канвас

## Чек-лист

- [x] Назначен исполнитель PR
- [x] eslint/stylelint и dev-консоль браузера без ошибок
- [ ] Написаны тесты или заведена задача на покрытие тестами

## Дополнительно

- [ ] проверять все разрешения, когда меняется верстка
- [ ] Указан `no_test` лейбл в задаче, если не требуется тестирование QA
- [ ] В задаче описано, как тестировать изменения (если это нужно)
