### PR TITLE
[VEGA-3004] refactor(canvas): Замена id Canvas node на vid с сервера

### DIFF
--- a/__test__/actions/logic-constructor-actions.test.ts
+++ b/__test__/actions/logic-constructor-actions.test.ts
@@ -1,0 +1,142 @@
+import { Dispatch } from 'react';
+import { IconAlert } from '@gpn-prototypes/vega-ui';
+import { waitFor } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import thunkMiddleware from 'redux-thunk';
+
+import { LogicConstructorActionTypes } from '../../src/redux-store/logic-constructor/action-types';
+import { syncCanvasState } from '../../src/redux-store/logic-constructor/actions';
+import initialState from '../../src/redux-store/logic-constructor/initial-state';
+import { StoreLC } from '../../src/types/redux-store';
+import * as graphqlRequest from '../../src/utils/graphql-request';
+
+const mockStore = configureMockStore([thunkMiddleware]);
+
+jest.mock('@/utils/graphql-request', () => {
+  const originalModule = jest.requireActual('@/utils/graphql-request');
+
+  return {
+    ...originalModule,
+    scenarioStepCreateMutation: jest.fn(),
+    canvasNodeCreateMutation: jest.fn(),
+  };
+});
+
+const mockQuery = (options: {
+  method: 'scenarioStepCreateMutation' | 'canvasNodeCreateMutation';
+  response?: any;
+  error?: any;
+}) => {
+  const { method, response, error = 'NetworkError' } = options;
+
+  jest.spyOn(graphqlRequest, method).mockImplementation(() => {
+    return new Promise((resolve, reject) => {
+      if (response) {
+        resolve(response);
+
+        return;
+      }
+
+      reject(error);
+    });
+  });
+};
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+const mockedCreateCanvasNode = {
+  data: {
+    logic: {
+      canvas: {
+        create: {
+          result: {
+            vid: 'created_canvas_node_id',
+          },
+        },
+      },
+    },
+  },
+};
+
+const mockedCreateScenarioStep = {
+  data: {
+    logic: {
+      scenarioStep: {
+        create: {
+          result: {
+            vid: 'scenario_step_id',
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('Objects group actions', () => {
+  let mockState: Partial<StoreLC>;
+
+  beforeEach(() => {
+    mockState = {
+      logicConstructor: {
+        ...initialState,
+        scenarioList: [
+          {
+            name: 'mock name',
+            vid: 'mock step vid',
+            itemList: [],
+          },
+        ],
+        canvasElements: [
+          {
+            id: 'mock_id',
+            getId() {
+              return this.id;
+            },
+            getChildren() {
+              return [];
+            },
+            getParents() {
+              return [];
+            },
+            getData() {
+              return this.data;
+            },
+            setData(data) {
+              this.data = data;
+            },
+            data: {
+              type: 'step',
+              position: { x: 0, y: 0 },
+              title: 'mock step title',
+            },
+          },
+        ],
+        isStepEditorOpened: true,
+      },
+    };
+  });
+
+  test('Происходит подмена ID при создании canvas node', async () => {
+    const store = mockStore(mockState);
+
+    mockQuery({ method: 'scenarioStepCreateMutation', response: mockedCreateScenarioStep });
+    mockQuery({ method: 'canvasNodeCreateMutation', response: mockedCreateCanvasNode });
+
+    (store.dispatch as Dispatch<any>)(
+      syncCanvasState({
+        type: 'add-tree',
+        id: 'mock_id',
+      }),
+    );
+
+    const expectedAction = {
+      type: LogicConstructorActionTypes.REPLACE_CANVAS_ELEMENT_ID,
+      id: 'mock_id',
+      replaceId: 'created_canvas_node_id',
+    };
+
+    await waitFor(() => expect(store.getActions()).toContainEqual(expectedAction));
+  });
+});

--- a/__test__/reducers/logic-constructor-reducer.test.ts
+++ b/__test__/reducers/logic-constructor-reducer.test.ts
@@ -23,6 +23,20 @@ describe('logic constructor reducer test', () => {
       ],
       canvasElements: [
         {
+          id: 'mock id',
+          getId() {
+            return this.id;
+          },
+          getChildren() {
+            return [];
+          },
+          getParents() {
+            return [];
+          },
+          getData() {
+            return this.data;
+          },
+          data: {},
           title: 'mock title',
           type: 'step',
           position: { x: 0, y: 0 },
@@ -71,5 +85,15 @@ describe('logic constructor reducer test', () => {
     const action = clearStores();
     const newState = logicConstructorReducer(mockState, action);
     expect(newState).toEqual(initialState);
+  });
+
+  test('происходит замена ID элемента канвас', () => {
+    const action = {
+      type: LogicConstructorActionTypes.REPLACE_CANVAS_ELEMENT_ID,
+      id: 'mock id',
+      replaceId: 'replaced id',
+    };
+    const newState = logicConstructorReducer(mockState, action);
+    expect(newState.canvasElements[0].id).toEqual('replaced id');
   });
 });

--- a/src/redux-store/logic-constructor/action-types.ts
+++ b/src/redux-store/logic-constructor/action-types.ts
@@ -3,6 +3,7 @@ import { applyActionTypesNames } from '@/utils/apply-action-types-names';
 type LogicConstructorActions =
   | 'SET_SCENARIO_LIST'
   | 'SET_CANVAS_ELEMENTS'
+  | 'REPLACE_CANVAS_ELEMENT_ID'
   | 'ADD_CANVAS_ELEMENT'
   | 'CREATE_STEP'
   | 'UPDATE_STEP'
@@ -13,6 +14,7 @@ type LogicConstructorActions =
 const LogicConstructorActionTypes: Record<LogicConstructorActions, string> = {
   SET_SCENARIO_LIST: '',
   SET_CANVAS_ELEMENTS: '',
+  REPLACE_CANVAS_ELEMENT_ID: '',
   ADD_CANVAS_ELEMENT: '',
   CREATE_STEP: '',
   UPDATE_STEP: '',

--- a/src/redux-store/logic-constructor/actions.ts
+++ b/src/redux-store/logic-constructor/actions.ts
@@ -55,6 +55,12 @@ type SetCanvasElements = {
   canvasElements: CanvasTree[];
 };
 
+type ReplaceCanvasElementId = {
+  type: typeof LogicConstructorActionTypes.REPLACE_CANVAS_ELEMENT_ID;
+  id: string;
+  replaceId: string;
+};
+
 const setScenarioList = (scenarioList: Step[]): SetScenarioList => ({
   type: LogicConstructorActionTypes.SET_SCENARIO_LIST,
   scenarioList,
@@ -90,6 +96,11 @@ const toggleStepEditor = (
     isStepEditorOpened,
   });
 };
+const replaceCanvasElementId = (id: string, replaceId: string): ReplaceCanvasElementId => ({
+  type: LogicConstructorActionTypes.REPLACE_CANVAS_ELEMENT_ID,
+  id,
+  replaceId,
+});
 
 let debouncedSetCanvasElements: DebounceFunction<CanvasTree[]>;
 export const setDebouncedCanvasElements = (
@@ -340,14 +351,16 @@ const syncCanvasState = (
           tree.setData({ stepData: { id: nodeRef, name: 'Шаг', events: [] } });
         }
 
-        await canvasNodeCreateMutation({
-          vid: updateData.id,
+        const response = await canvasNodeCreateMutation({
           title,
           nodeType,
           width: treeWidth,
           position: [pos.x, pos.y],
           nodeRef,
         });
+        const id = response?.data?.logic?.canvas?.create?.result?.vid;
+
+        dispatch(replaceCanvasElementId(updateData.id, id));
       }
 
       return;

--- a/src/redux-store/logic-constructor/reducer.ts
+++ b/src/redux-store/logic-constructor/reducer.ts
@@ -1,4 +1,4 @@
-import { CanvasTree } from '@gpn-prototypes/vega-ui';
+import { CanvasData, CanvasTree, entities } from '@gpn-prototypes/vega-ui';
 
 import { ClearActionTypes } from '../clear/action-types';
 
@@ -56,9 +56,33 @@ const clearStoreStrategy = (): LogicConstructorState => ({
   ...initialState,
 });
 
+const replaceCanvasElementIdStrategy = (
+  state: LogicConstructorState,
+  { id, replaceId }: { id: string; replaceId: string },
+): LogicConstructorState => {
+  const canvasElements = state.canvasElements || [];
+  const found = canvasElements.find((i) => i.getId() === id);
+
+  if (!found) return state; // todo: throw error?
+
+  return {
+    ...state,
+    canvasElements: [
+      ...canvasElements.filter((i) => i.getId() !== id),
+      entities.Tree.of<CanvasData>({
+        id: replaceId,
+        childrenIds: found.getChildren(),
+        parentIds: found.getParents(),
+        data: found.getData(),
+      }),
+    ],
+  };
+};
+
 const strategyMap = {
   [LogicConstructorActionTypes.SET_SCENARIO_LIST]: setScenarioListStrategy,
   [LogicConstructorActionTypes.SET_CANVAS_ELEMENTS]: setCanvasElementsStrategy,
+  [LogicConstructorActionTypes.REPLACE_CANVAS_ELEMENT_ID]: replaceCanvasElementIdStrategy,
   [LogicConstructorActionTypes.ADD_CANVAS_ELEMENT]: addCanvasElementStrategy,
   [LogicConstructorActionTypes.TOGGLE_STEP_EDITOR]: toggleStepEditorStrategy,
   [LogicConstructorActionTypes.SET_CANVAS_VIEW_REF]: setCanvasViewRefStrategy,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -109,7 +109,6 @@ export const SCENARIO_STEP_UPDATE_MUTATION = gql`
 
 export const CANVAS_NODE_CREATE_MUTATION = gql`
   mutation(
-    $vid: UUID
     $title: String
     $nodeType: String!
     $width: Float
@@ -120,7 +119,6 @@ export const CANVAS_NODE_CREATE_MUTATION = gql`
     logic {
       canvas {
         create(
-          vid: $vid
           title: $title
           width: $width
           nodeType: $nodeType


### PR DESCRIPTION
## Задача
Задача в Jira: https://jira.vegaspace.tk/browse/VEGA-3004
http://ababakov-vega-3004-lanit-vega-builder.code013.org/

### Description
 Убрать vid при создании canvas node

### Checks
- [x] Jira link attached: [VEGA-3004](https://jira.vegaspace.tk/browse/VEGA-3004)
- [x] Possible Associated Jira links: https://git.konakov.tv/vega2/vega2-back-core/-/merge_requests/293
- [x] Personal Vega Instance link attached: http://ababakov-vega-3004-lanit-vega-builder.code013.org/
- [ ] Jira tasks for technical debt were created (if needed)

### Type
- [ ] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [ ] Bug Fix
- [ ] Test
- [x] Refactoring

### PR/MR Requirements
- [x] PR/MR title meet requirements/convention
- [x] Target branch is correct
- [x] PR/MR branch was rebased at correct branch
- [x] Diff was checked
- [ ] Configuration files were checked at test repositories
- [x] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General
- [x] Exploratory Tested at Personal Vega Instance
- [x] Existing E2E Tests done, Screenshot attached
- [x] Existing Integration Tests done, Screenshot attached, Jenkins link:
- [x] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed
- [x] New Integration Tests developed
- [x] New Unit Tests developed
- [ ] API documentation was fully and correctly updated

# Test check requirements
https://git.konakov.tv/vega2/vega2-back-core/-/merge_requests/293

