### PR TITLE
[VEGA-2929] feat(global): Переезд с Layout на SplitPanes

### DIFF
--- a/__test__/components/__snapshots__/geological-exploration.test.tsx.snap
+++ b/__test__/components/__snapshots__/geological-exploration.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Geological Exploration рендерится без ошибок 1`] = `
             Object {
               "flex": "1",
               "maxHeight": "calc(100% - 2px * 1)",
-              "minHeight": "90px",
+              "minHeight": "140px",
             }
           }
         >

--- a/__test__/components/__snapshots__/geological-exploration.test.tsx.snap
+++ b/__test__/components/__snapshots__/geological-exploration.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`Geological Exploration рендерится без ошибок 1`] = `
       tabIndex={-1}
     />
     <div
-      aria-label="canvas"
+      aria-label="logic-constructor"
       className="VegaSplitPanes__Pane"
       role="treeitem"
       style={

--- a/__test__/components/__snapshots__/geological-exploration.test.tsx.snap
+++ b/__test__/components/__snapshots__/geological-exploration.test.tsx.snap
@@ -18,17 +18,17 @@ exports[`Geological Exploration рендерится без ошибок 1`] = `
     role="tree"
   >
     <div
-      className={
+      aria-label="trees"
+      className="VegaSplitPanes__Pane"
+      role="treeitem"
+      style={
         Object {
-          "has": [Function],
-          "is": [Function],
-          "mix": [Function],
-          "split": [Function],
-          "state": [Function],
-          "toString": [Function],
+          "flexGrow": 0,
+          "maxWidth": "260px",
+          "minWidth": "24px",
+          "width": "260px",
         }
       }
-      role="group"
     >
       <div
         className={
@@ -41,277 +41,67 @@ exports[`Geological Exploration рендерится без ошибок 1`] = `
             "toString": [Function],
           }
         }
-        role="group"
+        role="tree"
       >
         <div
-          className={
+          aria-label="project-structure"
+          className="VegaSplitPanes__Pane"
+          role="treeitem"
+          style={
             Object {
-              "has": [Function],
-              "is": [Function],
-              "mix": [Function],
-              "split": [Function],
-              "state": [Function],
-              "toString": [Function],
+              "flex": "1",
+              "maxHeight": "calc(100% - 2px * 1)",
+              "minHeight": "50px",
             }
           }
-          role="treeitem"
         >
-          <header
-            className={
-              Object {
-                "has": [Function],
-                "is": [Function],
-                "mix": [Function],
-                "split": [Function],
-                "state": [Function],
-                "toString": [Function],
-              }
-            }
-          >
-            <button
-              aria-label="Открыть список виджетов"
-              className="Button Button_size_xs Button_view_clear Button_width_default Button_form_brick Button_withIcon MixFocus VegaLayout__MenuTrigger"
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="Button-Label"
-              >
-                Структура проекта
-              </span>
-              <span
-                className="Icon Icon_size_xs IconSelect Button-Icon Button-Icon_position_right"
-              >
-                <svg
-                  className="Icon-Svg"
-                  viewBox="0 0 12 12"
-                >
-                  <path
-                    d="M6 8.5L10 4H2l4 4.5z"
-                  />
-                </svg>
-              </span>
-            </button>
-            <button
-              aria-label="Открыть опции панели"
-              className="Button Button_size_xs Button_view_clear Button_width_default Button_form_brick Button_withIcon Button_onlyIcon MixFocus"
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="Icon Icon_size_s IconKebab Button-Icon"
-              >
-                <svg
-                  className="Icon-Svg"
-                  viewBox="0 0 16 16"
-                >
-                  <path
-                    d="M8 4.5c.83 0 1.5-.67 1.5-1.5S8.83 1.5 8 1.5 6.5 2.17 6.5 3 7.17 4.5 8 4.5zm0 2c-.83 0-1.5.67-1.5 1.5S7.17 9.5 8 9.5 9.5 8.83 9.5 8 8.83 6.5 8 6.5zm0 5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </header>
-          <div
-            className={
-              Object {
-                "has": [Function],
-                "is": [Function],
-                "mix": [Function],
-                "split": [Function],
-                "state": [Function],
-                "toString": [Function],
-              }
-            }
-          >
-            <div />
-          </div>
+          <div />
         </div>
         <div
-          aria-label="Потянуть"
-          className="VegaLayout__Resizer VegaLayout__Resizer_split_vertical"
+          aria-current={false}
+          aria-label="Изменить размер"
+          className="VegaSplitPanes__Resizer VegaSplitPanes__Resizer_split_horizontal"
           onMouseDown={[Function]}
-          role="button"
+          role="presentation"
           tabIndex={-1}
-          title="Потянуть"
         />
         <div
-          className={
-            Object {
-              "has": [Function],
-              "is": [Function],
-              "mix": [Function],
-              "split": [Function],
-              "state": [Function],
-              "toString": [Function],
-            }
-          }
+          aria-label="objects-groups"
+          className="VegaSplitPanes__Pane"
           role="treeitem"
-        >
-          <header
-            className={
-              Object {
-                "has": [Function],
-                "is": [Function],
-                "mix": [Function],
-                "split": [Function],
-                "state": [Function],
-                "toString": [Function],
-              }
-            }
-          >
-            <button
-              aria-label="Открыть список виджетов"
-              className="Button Button_size_xs Button_view_clear Button_width_default Button_form_brick Button_withIcon MixFocus VegaLayout__MenuTrigger"
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="Button-Label"
-              >
-                Группа объектов
-              </span>
-              <span
-                className="Icon Icon_size_xs IconSelect Button-Icon Button-Icon_position_right"
-              >
-                <svg
-                  className="Icon-Svg"
-                  viewBox="0 0 12 12"
-                >
-                  <path
-                    d="M6 8.5L10 4H2l4 4.5z"
-                  />
-                </svg>
-              </span>
-            </button>
-            <button
-              aria-label="Открыть опции панели"
-              className="Button Button_size_xs Button_view_clear Button_width_default Button_form_brick Button_withIcon Button_onlyIcon MixFocus"
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="Icon Icon_size_s IconKebab Button-Icon"
-              >
-                <svg
-                  className="Icon-Svg"
-                  viewBox="0 0 16 16"
-                >
-                  <path
-                    d="M8 4.5c.83 0 1.5-.67 1.5-1.5S8.83 1.5 8 1.5 6.5 2.17 6.5 3 7.17 4.5 8 4.5zm0 2c-.83 0-1.5.67-1.5 1.5S7.17 9.5 8 9.5 9.5 8.83 9.5 8 8.83 6.5 8 6.5zm0 5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </header>
-          <div
-            className={
-              Object {
-                "has": [Function],
-                "is": [Function],
-                "mix": [Function],
-                "split": [Function],
-                "state": [Function],
-                "toString": [Function],
-              }
-            }
-          >
-            <div />
-          </div>
-        </div>
-      </div>
-      <div
-        aria-label="Потянуть"
-        className="VegaLayout__Resizer VegaLayout__Resizer_split_horizontal"
-        onMouseDown={[Function]}
-        role="button"
-        tabIndex={-1}
-        title="Потянуть"
-      />
-      <div
-        className={
-          Object {
-            "has": [Function],
-            "is": [Function],
-            "mix": [Function],
-            "split": [Function],
-            "state": [Function],
-            "toString": [Function],
-          }
-        }
-        role="treeitem"
-      >
-        <header
-          className={
+          style={
             Object {
-              "has": [Function],
-              "is": [Function],
-              "mix": [Function],
-              "split": [Function],
-              "state": [Function],
-              "toString": [Function],
-            }
-          }
-        >
-          <button
-            aria-label="Открыть список виджетов"
-            className="Button Button_size_xs Button_view_clear Button_width_default Button_form_brick Button_withIcon MixFocus VegaLayout__MenuTrigger"
-            onClick={[Function]}
-            type="button"
-          >
-            <span
-              className="Button-Label"
-            >
-              Канвас
-            </span>
-            <span
-              className="Icon Icon_size_xs IconSelect Button-Icon Button-Icon_position_right"
-            >
-              <svg
-                className="Icon-Svg"
-                viewBox="0 0 12 12"
-              >
-                <path
-                  d="M6 8.5L10 4H2l4 4.5z"
-                />
-              </svg>
-            </span>
-          </button>
-          <button
-            aria-label="Открыть опции панели"
-            className="Button Button_size_xs Button_view_clear Button_width_default Button_form_brick Button_withIcon Button_onlyIcon MixFocus"
-            onClick={[Function]}
-            type="button"
-          >
-            <span
-              className="Icon Icon_size_s IconKebab Button-Icon"
-            >
-              <svg
-                className="Icon-Svg"
-                viewBox="0 0 16 16"
-              >
-                <path
-                  d="M8 4.5c.83 0 1.5-.67 1.5-1.5S8.83 1.5 8 1.5 6.5 2.17 6.5 3 7.17 4.5 8 4.5zm0 2c-.83 0-1.5.67-1.5 1.5S7.17 9.5 8 9.5 9.5 8.83 9.5 8 8.83 6.5 8 6.5zm0 5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5z"
-                />
-              </svg>
-            </span>
-          </button>
-        </header>
-        <div
-          className={
-            Object {
-              "has": [Function],
-              "is": [Function],
-              "mix": [Function],
-              "split": [Function],
-              "state": [Function],
-              "toString": [Function],
+              "flex": "1",
+              "maxHeight": "calc(100% - 2px * 1)",
+              "minHeight": "90px",
             }
           }
         >
           <div />
         </div>
       </div>
+    </div>
+    <div
+      aria-current={false}
+      aria-label="Изменить размер"
+      className="VegaSplitPanes__Resizer VegaSplitPanes__Resizer_split_vertical"
+      onMouseDown={[Function]}
+      role="presentation"
+      tabIndex={-1}
+    />
+    <div
+      aria-label="canvas"
+      className="VegaSplitPanes__Pane"
+      role="treeitem"
+      style={
+        Object {
+          "flex": "1",
+          "maxWidth": "calc(100% - 2px * 1)",
+          "minWidth": "0",
+        }
+      }
+    >
+      <div />
     </div>
   </div>
 </div>

--- a/__test__/components/__snapshots__/objects-group.test.tsx.snap
+++ b/__test__/components/__snapshots__/objects-group.test.tsx.snap
@@ -5,35 +5,27 @@ exports[`Geological Exploration рендерится без ошибок 1`] = `
   className="ObjectsGroupWidget"
 >
   <div
-    className="VegaTree"
+    className="ComponentHeader"
   >
-    <div
-      className={
-        Object {
-          "has": [Function],
-          "is": [Function],
-          "mix": [Function],
-          "split": [Function],
-          "state": [Function],
-          "toString": [Function],
-        }
+    <p>
+      Группы объектов
+    </p>
+  </div>
+  <div
+    className={
+      Object {
+        "has": [Function],
+        "is": [Function],
+        "mix": [Function],
+        "split": [Function],
+        "state": [Function],
+        "toString": [Function],
       }
-    >
-      <ul
-        className={
-          Object {
-            "has": [Function],
-            "is": [Function],
-            "mix": [Function],
-            "split": [Function],
-            "state": [Function],
-            "toString": [Function],
-          }
-        }
-        role="tree"
-        tabIndex={0}
-      />
-    </div>
+    }
+  >
+    <p>
+      Для создания группы нажмите на кнопку Добавить группу
+    </p>
   </div>
   <div
     className={

--- a/__test__/components/__snapshots__/project-structure.test.tsx.snap
+++ b/__test__/components/__snapshots__/project-structure.test.tsx.snap
@@ -5,6 +5,13 @@ exports[`Geological Exploration рендерится без ошибок 1`] = `
   className="ProjectStructure"
 >
   <div
+    className="ComponentHeader"
+  >
+    <p>
+      Структура проекта
+    </p>
+  </div>
+  <div
     className={
       Object {
         "has": [Function],

--- a/__test__/components/geological-exploration.test.tsx
+++ b/__test__/components/geological-exploration.test.tsx
@@ -73,6 +73,20 @@ describe('Geological Exploration', () => {
     expect(dom).toMatchSnapshot();
   });
 
+  test('Основные компоненты присутствуют в DOM', () => {
+    const { container } = render(
+      <ReactRedux.Provider store={store}>
+        <GeologicalExploration />
+      </ReactRedux.Provider>,
+    );
+
+    const mainComponentLabels = ['project-structure', 'objects-groups', 'logic-constructor'];
+
+    mainComponentLabels.forEach((label) =>
+      expect(container.querySelector(`[aria-label="${label}"]`)).toBeInTheDocument(),
+    );
+  });
+
   test('вызывать загрузку данных проекта если он инициализирован', async () => {
     renderComponent('', true);
 

--- a/__test__/components/geological-exploration.test.tsx
+++ b/__test__/components/geological-exploration.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Provider } from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
 import renderer from 'react-test-renderer';
 import { render } from '@testing-library/react';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -51,11 +51,11 @@ beforeEach(() => {
 
 const renderComponent = (projectId = '', initialized = false) => {
   return render(
-    <Provider store={store}>
+    <ReduxProvider store={store}>
       <ProjectContext.Provider value={{ projectId, initialized }}>
         <GeologicalExploration />
       </ProjectContext.Provider>
-    </Provider>,
+    </ReduxProvider>,
   );
 };
 
@@ -65,9 +65,9 @@ describe('Geological Exploration', () => {
 
     const dom = renderer
       .create(
-        <Provider store={store}>
+        <ReduxProvider store={store}>
           <GeologicalExploration />
-        </Provider>,
+        </ReduxProvider>,
       )
       .toJSON();
     expect(dom).toMatchSnapshot();
@@ -75,9 +75,9 @@ describe('Geological Exploration', () => {
 
   test('Основные компоненты присутствуют в DOM', () => {
     const { container } = render(
-      <ReactRedux.Provider store={store}>
+      <ReduxProvider store={store}>
         <GeologicalExploration />
-      </ReactRedux.Provider>,
+      </ReduxProvider>,
     );
 
     const mainComponentLabels = ['project-structure', 'objects-groups', 'logic-constructor'];

--- a/src/App/App.css
+++ b/src/App/App.css
@@ -36,3 +36,7 @@
 .SelectDropdown {
   z-index: 1;
 }
+
+.VegaTree__RootList {
+  margin-top: 0;
+}

--- a/src/components/activities/index.css
+++ b/src/components/activities/index.css
@@ -27,7 +27,7 @@
   }
 
   &__Head {
-    padding: 8px;
+    padding: 8px 8px 10px;
   }
 
   &__Title {

--- a/src/components/components-header/cn-header.ts
+++ b/src/components/components-header/cn-header.ts
@@ -1,0 +1,3 @@
+import BemCn from 'bem-cn';
+
+export const cnComponentHeader = BemCn('ComponentHeader');

--- a/src/components/components-header/index.css
+++ b/src/components/components-header/index.css
@@ -1,0 +1,20 @@
+.ComponentHeader {
+  padding: 0 12px;
+
+  width: 100%;
+  height: 24px;
+
+  background: var(--color-bg-default);
+
+  border-bottom: 1px solid var(--color-bg-secondary);
+
+  p {
+    margin: 0;
+
+    font-size: 12px;
+    line-height: 24px;
+    white-space: nowrap;
+
+    color: var(--color-control-typo-clear);
+  }
+}

--- a/src/components/components-header/index.tsx
+++ b/src/components/components-header/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import './index.css';
+
+import { cnComponentHeader } from '@/components/components-header/cn-header';
+
+type ComponentHeaderProps = {
+  title: string;
+};
+
+export const ComponentHeader: React.FC<ComponentHeaderProps> = ({ title }) => {
+  return (
+    <div className={cnComponentHeader()}>
+      <p>{title}</p>
+    </div>
+  );
+};

--- a/src/components/geological-exploration/index.tsx
+++ b/src/components/geological-exploration/index.tsx
@@ -50,7 +50,7 @@ export const GeologicalExploration = (): React.ReactElement => {
             <SplitPanes.Pane aria-label="project-structure" min="50px">
               <ProjectStructureWidget />
             </SplitPanes.Pane>
-            <SplitPanes.Pane aria-label="objects-groups" min="90px">
+            <SplitPanes.Pane aria-label="objects-groups" min="140px">
               <ObjectsGroupWidget />
             </SplitPanes.Pane>
           </SplitPanes>

--- a/src/components/geological-exploration/index.tsx
+++ b/src/components/geological-exploration/index.tsx
@@ -1,13 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import {
-  GridState,
-  GridUpdate,
-  IconProcessing,
-  Layout,
-  LayoutWidget,
-  LayoutWidgetsOverrides,
-} from '@gpn-prototypes/vega-ui';
+import { IconProcessing, SplitPanes } from '@gpn-prototypes/vega-ui';
 
 import { LogicConstructorWidget } from '../logic-constructor';
 import { ObjectsGroupWidget } from '../objects-group';
@@ -25,10 +18,6 @@ import { setNotification } from '@/redux-store/notifications/actions';
 import { fetchProjectStructureList } from '@/redux-store/project-structure/actions';
 
 export const GeologicalExploration = (): React.ReactElement => {
-  function action(change: { update: GridUpdate; state: GridState }): void {
-    console.log(change);
-  }
-
   const dispatch = useDispatch();
   const { projectId, initialized } = useContext(ProjectContext);
 
@@ -53,73 +42,23 @@ export const GeologicalExploration = (): React.ReactElement => {
     }
   }, [dispatch, initialized]);
 
-  const widgets: LayoutWidget[] = [
-    {
-      name: 'Группа объектов',
-      component: 'vega-group-objects',
-    },
-    {
-      name: 'Структура проекта',
-      component: 'vega-project-structure',
-    },
-    {
-      name: 'Канвас',
-      component: 'vega-canvas',
-    },
-  ];
-
-  const widgetsOverrides: LayoutWidgetsOverrides = {
-    'vega-group-objects': () => <ObjectsGroupWidget />,
-    'vega-project-structure': () => <ProjectStructureWidget />,
-    'vega-canvas': () => <LogicConstructorWidget />,
-  };
-
-  const state: GridState = {
-    0: {
-      type: 'branch',
-      data: {
-        splitDirection: 'right',
-        breakpoint: 14,
-      },
-    },
-    1: {
-      type: 'branch',
-      data: {
-        splitDirection: 'down',
-        breakpoint: 51,
-      },
-    },
-    2: {
-      type: 'leaf',
-      data: {
-        widget: 'vega-canvas',
-        context: {},
-      },
-    },
-    3: {
-      type: 'leaf',
-      data: {
-        widget: 'vega-project-structure',
-        context: {},
-      },
-    },
-    4: {
-      type: 'leaf',
-      data: {
-        widget: 'vega-group-objects',
-        context: {},
-      },
-    },
-  };
-
   return (
     <div className={cnGeologicalExploration()}>
-      <Layout
-        state={state}
-        widgets={widgets}
-        widgetsOverrides={widgetsOverrides}
-        onChange={action}
-      />
+      <SplitPanes split="vertical">
+        <SplitPanes.Pane aria-label="trees" initialSize="260px" min="24px" max="260px">
+          <SplitPanes split="horizontal">
+            <SplitPanes.Pane aria-label="project-structure" min="50px">
+              <ProjectStructureWidget />
+            </SplitPanes.Pane>
+            <SplitPanes.Pane aria-label="objects-groups" min="90px">
+              <ObjectsGroupWidget />
+            </SplitPanes.Pane>
+          </SplitPanes>
+        </SplitPanes.Pane>
+        <SplitPanes.Pane aria-label="canvas">
+          <LogicConstructorWidget />
+        </SplitPanes.Pane>
+      </SplitPanes>
     </div>
   );
 };

--- a/src/components/geological-exploration/index.tsx
+++ b/src/components/geological-exploration/index.tsx
@@ -55,7 +55,7 @@ export const GeologicalExploration = (): React.ReactElement => {
             </SplitPanes.Pane>
           </SplitPanes>
         </SplitPanes.Pane>
-        <SplitPanes.Pane aria-label="canvas">
+        <SplitPanes.Pane aria-label="logic-constructor">
           <LogicConstructorWidget />
         </SplitPanes.Pane>
       </SplitPanes>

--- a/src/components/objects-group/index.css
+++ b/src/components/objects-group/index.css
@@ -99,8 +99,12 @@
   }
 
   &__NoStructure {
+    padding: 0 10px;
+
     display: flex;
     justify-content: center;
+
+    min-width: 150px;
 
     & > p {
       margin: 0;

--- a/src/components/objects-group/index.css
+++ b/src/components/objects-group/index.css
@@ -1,6 +1,8 @@
 .ObjectsGroupWidget {
-  position: relative;
+  display: flex;
+  flex-direction: column;
 
+  width: 100%;
   height: 100%;
 
   & > .VegaTree {
@@ -10,10 +12,10 @@
   }
 
   &__GroupCreator {
-    position: absolute;
     z-index: 1;
-    left: 0;
-    bottom: 16px;
+
+    margin-top: auto;
+    margin-bottom: 16px;
 
     padding: 0 16px;
 
@@ -94,5 +96,21 @@
     background-color: transparent;
     border: none;
     opacity: 0.4;
+  }
+
+  &__NoStructure {
+    display: flex;
+    justify-content: center;
+
+    & > p {
+      margin: 0;
+      padding: var(--space-xs) 0;
+
+      font-size: var(--size-text-xs);
+
+      text-align: center;
+
+      color: var(--color-typo-secondary);
+    }
   }
 }

--- a/src/components/objects-group/index.tsx
+++ b/src/components/objects-group/index.tsx
@@ -8,6 +8,7 @@ import { ObjectsGroupDialog } from './ObjectsGroupDialog';
 
 import './index.css';
 
+import { ComponentHeader } from '@/components/components-header';
 import {
   setGroupObjectsDraggingElements,
   toggleDialog,
@@ -67,14 +68,22 @@ export const ObjectsGroupWidget: React.FC = (): React.ReactElement => {
 
   return (
     <div className={cnObjectGroup()}>
-      <Tree
-        icons={icons}
-        nodeList={objectGroupList || []}
-        showIndentGuides={false}
-        onPasteItem={handlePaste}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-      />
+      <ComponentHeader title="Группы объектов" />
+
+      {objectGroupList?.length ? (
+        <Tree
+          icons={icons}
+          nodeList={objectGroupList}
+          showIndentGuides={false}
+          onPasteItem={handlePaste}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+        />
+      ) : (
+        <div className={cnObjectGroup('NoStructure')}>
+          <p>Для создания группы нажмите на кнопку Добавить группу</p>
+        </div>
+      )}
 
       <div className={cnObjectGroup('GroupCreator')}>
         <Button

--- a/src/components/project-structure/index.css
+++ b/src/components/project-structure/index.css
@@ -1,6 +1,8 @@
 .ProjectStructure {
   position: relative;
 
+  width: 100%;
+
   height: 100%;
 
   & > .VegaTree {

--- a/src/components/project-structure/index.tsx
+++ b/src/components/project-structure/index.tsx
@@ -7,6 +7,7 @@ import { BlueLineSvg, OrangeLineSvg, RedLineSvg } from './icons';
 
 import './index.css';
 
+import { ComponentHeader } from '@/components/components-header';
 import { setProjectStructureDraggingElements } from '@/redux-store/project-structure/actions';
 import { getProjectStructureNodeList } from '@/redux-store/project-structure/selectors';
 
@@ -30,19 +31,23 @@ export const ProjectStructureWidget: React.FC = (): React.ReactElement => {
 
   return (
     <div className={cnProjectStructure()}>
-      {!projectStructure?.length ? (
-        <div className={cnProjectStructure('NoStructure')}>
-          <p>Структура проекта отсутствует</p>
-        </div>
-      ) : (
-        <Tree
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          icons={icons}
-          isContextMenuEnable
-          nodeList={projectStructure || []}
-        />
-      )}
+      <>
+        <ComponentHeader title="Структура проекта" />
+
+        {!projectStructure?.length ? (
+          <div className={cnProjectStructure('NoStructure')}>
+            <p>Структура проекта отсутствует</p>
+          </div>
+        ) : (
+          <Tree
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            icons={icons}
+            isContextMenuEnable
+            nodeList={projectStructure || []}
+          />
+        )}
+      </>
     </div>
   );
 };

--- a/src/react-context/providers/Providers.tsx
+++ b/src/react-context/providers/Providers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Provider } from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/client';
 import { Loader } from '@gpn-prototypes/vega-ui';
@@ -20,7 +20,7 @@ export const Providers: React.FC<ProvidersProps> = (props) => {
   const { graphqlClient = vegaApi, identity, children } = props;
 
   return (
-    <Provider store={store}>
+    <ReduxProvider store={store}>
       <ApolloProvider client={graphqlClient}>
         <PersistGate loading={<Loader size="m" />} persistor={persistor}>
           <BrowserRouter>
@@ -30,6 +30,6 @@ export const Providers: React.FC<ProvidersProps> = (props) => {
           </BrowserRouter>
         </PersistGate>
       </ApolloProvider>
-    </Provider>
+    </ReduxProvider>
   );
 };

--- a/src/redux-store/notifications/actions.ts
+++ b/src/redux-store/notifications/actions.ts
@@ -1,6 +1,6 @@
-import { Notification } from '../../types/redux-store';
-
 import { VersionActionTypes } from './action-types';
+
+import { Notification } from '@/types/redux-store';
 
 type SetNotification = {
   type: typeof VersionActionTypes.SET_NOTIFICATION;


### PR DESCRIPTION
### Description
Замена компонента формирующего интерактивную сетку компонентов (с Layout на SplitPanes)

### Checks
- [x] Jira link attached: https://jira.konakov.tv/browse/VEGA-2929
- [ ] Possible Associated Jira links:
- [x] Personal Vega Instance link attached: http://dbokovikov-lanit-vega-builder.code013.org/
- [ ] Jira tasks for technical debt were created (if needed)

### Type
- [x] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [ ] Bug Fix
- [ ] Test
- [ ] Refactoring

### PR/MR Requirements
- [x] PR/MR title meet requirements/convention
- [x] Target branch is correct
- [x] PR/MR branch was rebased at correct branch
- [x] Diff was checked
- [ ] Configuration files were checked at test repositories
- [x] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General
- [ ] Exploratory Tested at Personal Vega Instance
- [x] Existing E2E Tests done, Screenshot attached
- [ ] Existing Integration Tests done, Screenshot attached, Jenkins link: 
- [x] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed 
- [ ] New Integration Tests developed
- [x] New Unit Tests developed

### E2E Suite Jenkins link
http://jenkins-remote-ci-gpn-vega-builder.code013.org:8081/job/STAND%20TOOLBOX/job/scenario-tests-on-demand/145/
### E2E Suite Screenshot

![image](https://user-images.githubusercontent.com/43147386/106779818-6ace6b00-6658-11eb-9697-3d3e68d79a5d.png)


### Unit Tests Screenshot

![image](https://user-images.githubusercontent.com/43147386/106749106-28e0fd00-6637-11eb-976e-978f74ade083.png)

