### PR TITLE
[VEGA-2839] fix(components): Исправление очистки формы при закрытии модального окна

### DIFF
--- a/__test__/components/form/TextField.test.tsx
+++ b/__test__/components/form/TextField.test.tsx
@@ -1,13 +1,32 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { Field, Form } from 'react-final-form';
+import { Form as VegaForm } from '@gpn-prototypes/vega-ui';
+import { fireEvent, render, screen } from '@testing-library/react';
 import ResizeObserver from 'resize-observer-polyfill';
 
 import '@/types/global';
 
 import { TextField, TextFieldProps } from '@/components/form';
 
-const renderComponent = (props: TextFieldProps) => {
-  return render(<TextField {...props} />);
+const renderWithForm = (props: TextFieldProps) => {
+  return render(
+    <Form
+      initialValues={{ test: '' }}
+      onSubmit={jest.fn()}
+      render={({ handleSubmit }): React.ReactNode => (
+        <VegaForm onSubmit={handleSubmit}>
+          <Field
+            name="test"
+            render={({ input, meta }): React.ReactNode => {
+              const fieldInput = { ...input, ...props.input };
+              const fieldMeta = { ...meta, ...props.meta };
+              return <TextField {...props} input={fieldInput} meta={fieldMeta} />;
+            }}
+          />
+        </VegaForm>
+      )}
+    />,
+  );
 };
 
 beforeAll(() => {
@@ -15,21 +34,16 @@ beforeAll(() => {
 });
 
 const defaultMockProps: TextFieldProps = {
-  name: 'test',
-  placeholder: 'test placeholder',
   input: {
     name: 'test',
-    onBlur: jest.fn(),
-    onChange: jest.fn(),
-    onFocus: jest.fn(),
-    value: 'test',
   },
-  meta: {},
+  placeholder: 'test placeholder',
   testId: 'testid',
 };
+
 describe('Список мероприятий', () => {
   test('рендерится без ошибок', () => {
-    renderComponent(defaultMockProps);
+    renderWithForm(defaultMockProps);
   });
 
   test('Не показывает поле ошибки, если ошибок нет', () => {
@@ -41,7 +55,7 @@ describe('Список мероприятий', () => {
         modifiedSinceLastSubmit: false,
       },
     };
-    renderComponent(mockProps);
+    renderWithForm(mockProps);
 
     const textLabel = screen.queryByTestId('testid');
     const errorLabel = screen.queryByTestId('testid:error');
@@ -59,7 +73,7 @@ describe('Список мероприятий', () => {
         dirty: true,
       },
     };
-    renderComponent(mockProps);
+    renderWithForm(mockProps);
 
     const errorLabel = screen.getByTestId('testid:error');
 
@@ -77,11 +91,41 @@ describe('Список мероприятий', () => {
         modifiedSinceLastSubmit: false,
       },
     };
-    renderComponent(mockProps);
+    renderWithForm(mockProps);
 
     const errorLabel = screen.getByTestId('testid:error');
 
     expect(errorLabel).toBeVisible();
     expect(errorLabel).toHaveTextContent('server error');
+  });
+
+  test('Не делает trim содержимого на onBlur при trimOnBlur = undefined', () => {
+    const { getByPlaceholderText } = renderWithForm(defaultMockProps);
+
+    const textField = getByPlaceholderText(defaultMockProps.placeholder) as HTMLInputElement;
+
+    const text = '    test   ';
+
+    fireEvent.change(textField, { target: { value: text } });
+    fireEvent.blur(textField);
+
+    expect(textField.value).toBe(text);
+  });
+
+  test('Делает trim содержимого на onBlur при trimOnBlur = true', () => {
+    const mockProps = {
+      ...defaultMockProps,
+      trimOnBlur: true,
+    };
+    const { getByPlaceholderText } = renderWithForm(mockProps);
+
+    const textField = getByPlaceholderText(defaultMockProps.placeholder) as HTMLInputElement;
+
+    const text = '    test   ';
+
+    fireEvent.change(textField, { target: { value: text } });
+    fireEvent.blur(textField);
+
+    expect(textField.value).toBe(text.trim());
   });
 });

--- a/src/components/form/TextField/TextField.tsx
+++ b/src/components/form/TextField/TextField.tsx
@@ -14,12 +14,13 @@ export type TextFieldProps<T = any> = {
   input: FieldInputProps<T>;
   meta: FieldMetaState<T>;
   testId?: string;
+  trimOnBlur?: boolean;
 } & Partial<BaseTextFieldProps>;
 
 const cnTextField = cn('VegaTextField');
 
 export const TextField: React.FC<TextFieldProps> = (props) => {
-  const { input, meta, name, placeholder, testId, ...rest } = props;
+  const { input, meta, name, placeholder, testId, trimOnBlur, ...rest } = props;
 
   const submitErrorText = meta.submitError ? meta.submitError : undefined;
   const clientErrorValidation =
@@ -45,7 +46,12 @@ export const TextField: React.FC<TextFieldProps> = (props) => {
         autoComplete="off"
         value={input.value}
         onChange={({ e }): void => input.onChange(e)}
-        onBlur={input.onBlur}
+        onBlur={(e) => {
+          if (trimOnBlur) {
+            input.onChange(input.value.trim());
+          }
+          input.onBlur(e);
+        }}
         onFocus={input.onFocus}
         data-testid={testId}
         {...rest}

--- a/src/components/form/TextField/index.ts
+++ b/src/components/form/TextField/index.ts
@@ -1,1 +1,1 @@
-export { TextField } from './TextField';
+export { TextField, TextFieldProps } from './TextField';

--- a/src/components/objects-group/ObjectsGroupDialog.tsx
+++ b/src/components/objects-group/ObjectsGroupDialog.tsx
@@ -9,6 +9,7 @@ import {
   Switch,
   usePortal,
 } from '@gpn-prototypes/vega-ui';
+import { FormApi } from 'final-form';
 import createDecorator from 'final-form-focus';
 
 import { TextField as FormTextField } from '../form';
@@ -45,14 +46,17 @@ export const ObjectsGroupDialog: React.FC = () => {
     ],
   });
 
-  const handleCloseDialog = (): void => {
+  const handleCloseDialog = (form: FormApi<NewGroupParams, Partial<NewGroupParams>>): void => {
+    setTimeout(form.reset);
     dispatch(toggleDialog(false));
   };
 
-  const handleCreateObjectGroup = (values: NewGroupParams): void => {
-    console.log('handle dispatch', values);
+  const handleCreateObjectGroup = (
+    values: NewGroupParams,
+    form: FormApi<NewGroupParams, Partial<NewGroupParams>>,
+  ): void => {
     dispatch(createNewGroup(values.name.trim()));
-    handleCloseDialog();
+    handleCloseDialog(form);
   };
 
   const decorators = useMemo(() => [focusOnErrors], []);
@@ -69,7 +73,9 @@ export const ObjectsGroupDialog: React.FC = () => {
             className={cnObjectGroup('Dialog')}
             portal={portal}
             isOpen={isDialogOpen}
-            onClose={handleCloseDialog}
+            onClose={() => {
+              handleCloseDialog(form);
+            }}
             hasOverlay
           >
             <div className={cnObjectGroup('DialogContent')}>
@@ -112,8 +118,7 @@ export const ObjectsGroupDialog: React.FC = () => {
                   <Button type="submit" onClick={handleSubmit} size="s" label="Создать группу" />
                   <Button
                     onClick={() => {
-                      form.reset();
-                      handleCloseDialog();
+                      handleCloseDialog(form);
                     }}
                     size="s"
                     view="ghost"
@@ -124,8 +129,7 @@ export const ObjectsGroupDialog: React.FC = () => {
 
               <button
                 onClick={() => {
-                  form.reset();
-                  handleCloseDialog();
+                  handleCloseDialog(form);
                 }}
                 className={cnObjectGroup('DialogCloser')}
                 type="button"

--- a/src/components/objects-group/ObjectsGroupDialog.tsx
+++ b/src/components/objects-group/ObjectsGroupDialog.tsx
@@ -88,6 +88,7 @@ export const ObjectsGroupDialog: React.FC = () => {
                     <FormTextField
                       input={input}
                       meta={meta}
+                      trimOnBlur
                       className={cnObjectGroup('DialogInput').toString()}
                       placeholder="Введите название группы объектов"
                       width="full"


### PR DESCRIPTION
### Description
- Поправил сброс формы при закрытии по нажатию вне модального окна и при добавлении группы объектов
- Добавил trim на onBlur для текстового поля, сделал опциональным по передаче ```trimOnBlur: boolean``` 

### Checks
- [x] Jira link attached: [VEGA-2839](https://jira.vegaspace.tk/browse/VEGA-2839)
- [ ] Possible Associated Jira links:
- [x] Personal Vega Instance link attached: http://ltumoyakov-vega2839-lanit-vega-builder.code013.org
- [ ] Jira tasks for technical debt were created (if needed)

### Type
- [ ] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [x] Bug Fix
- [ ] Test
- [ ] Refactoring

### PR/MR Requirements
- [x] PR/MR title meet requirements/convention
- [x] Target branch is correct
- [x] PR/MR branch was rebased at correct branch
- [x] Diff was checked
- [ ] Configuration files were checked at test repositories
- [x] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General
- [ ] Exploratory Tested at Personal Vega Instance
- [x] Existing E2E Tests done, Screenshot attached
- [ ] Existing Integration Tests done, Screenshot attached, Jenkins link:
- [x] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed
- [ ] New Integration Tests developed
- [x] New Unit Tests developed
- [ ] API documentation was fully and correctly updated

### E2E Suite Jenkins link
http://jenkins-remote-ci-gpn-vega-builder.code013.org:8081/job/STAND%20TOOLBOX/job/scenario-tests-on-demand/291/

### E2E Suite Screenshot
![изображение](https://user-images.githubusercontent.com/21119774/108587696-b175d200-7387-11eb-8ddb-75cbc6d14e35.png)

### Unit Tests Screenshot
![изображение](https://user-images.githubusercontent.com/21119774/108586987-ee3fca00-7383-11eb-8723-4990bd61b7f5.png)

