### PR TITLE
[VEGA-3119] feat(components): Фикс невозможности переноса объекта в группу

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@bem-react/classnames": "^1.3.9",
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
-    "@gpn-prototypes/vega-ui": "^3.1.1",
+    "@gpn-prototypes/vega-ui": "^3.1.2",
     "bem-cn": "^3.0.1",
     "final-form": "^4.20.1",
     "final-form-focus": "^1.1.2",

--- a/src/components/objects-group/index.tsx
+++ b/src/components/objects-group/index.tsx
@@ -85,6 +85,7 @@ export const ObjectsGroupWidget: React.FC = (): React.ReactElement => {
           onPasteItem={handlePaste}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
+          isExternalDraggingElement={!!projectStructureDraggingElements.length}
         />
       ) : (
         <div className={cnObjectGroup('NoStructure')}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     webpack "^4.42.1"
     webpack-bundle-analyzer "^3.9.0"
 
-"@gpn-prototypes/vega-ui@^3.1.1":
-  version "3.1.1"
-  resolved "https://npm.pkg.github.com/download/@gpn-prototypes/vega-ui/3.1.1/811e4d16d351acf00e0a65a2bc9590ef989c08d7abf3058a15ff6c1e7a8ded9a#82b4567ac5225b25ccbf8383d6e68dcb837430de"
-  integrity sha1-grRWesUiWyXMv4OD1uaNy4N0MN4=
+"@gpn-prototypes/vega-ui@^3.1.2":
+  version "3.1.2"
+  resolved "https://npm.pkg.github.com/download/@gpn-prototypes/vega-ui/3.1.2/b19f7cb7d270e54e5e9ecf048b7de7ea6bd3a8b404965764e4c6e119abc97638#fca416628966fd05a693421e35f84c9a12d93cb0"
+  integrity sha512-tmXo92ZEVROptTLkgVYkEg8JXmbvsRvxiPuEGBbNIJgU0ExiGk+y8dw2Pqvio63paTCR7oeYjvKcbGN01Z74AQ==
   dependencies:
     "@consta/uikit" "^1.11.2"
     "@popperjs/core" "^2.6.0"


### PR DESCRIPTION
## Задача
Задача в Jira: https://jira.konakov.tv/browse/VEGA-3119
Ссылка на стенд: https://VEGA-3119.vega-2.csssr.cloud
Jira issue: VEGA-3119

### Description
- Прокинул параметр isExternalDraggingElement в компонент группы объектов

### Checks
- [x] Jira link attached: [VEGA-3119](https://jira.vegaspace.tk/browse/VEGA-3119)
- [ ] Possible Associated Jira links:
- [ ] Personal Vega Instance link attached: http://xx-yy-vega-builder.code013.org
- [ ] Jira tasks for technical debt were created (if needed)

### Type
- [ ] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [x] Bug Fix
- [ ] Test
- [ ] Refactoring

### PR/MR Requirements
- [ ] PR/MR title meet requirements/convention
- [x] Target branch is correct
- [x] PR/MR branch was rebased at correct branch
- [x] Diff was checked
- [ ] Configuration files were checked at test repositories
- [ ] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General
- [ ] Exploratory Tested at Personal Vega Instance
- [ ] Existing E2E Tests done, Screenshot attached
- [ ] Existing Integration Tests done, Screenshot attached, Jenkins link:
- [x] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed
- [ ] New Integration Tests developed
- [ ] New Unit Tests developed
- [ ] API documentation was fully and correctly updated

### E2E Suite Jenkins link
_{link}_

### E2E Suite Screenshot
_{Screenshot}_

### Integration Tests Screenshot
_{Screenshot}_

### Unit Tests Screenshot
![image](https://user-images.githubusercontent.com/43147386/109971886-c2b7ca80-7d07-11eb-803a-ef55d1ec9b20.png)

