### PR TITLE
VEGA-974: Удалить csssr из codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Yankovsky @c1n1k @fixmylie @Inzephirum @hitmanet @maksim-kononov-csssr @Davs777 @ababakov @DmitriiBo @lipgen
+* @Davs777 @ababakov @DmitriiBo @lipgen


### PR DESCRIPTION
## Задача
Задача в Jira: https://jira.konakov.tv/browse/VEGA-974
Jira issue: VEGA-974

### Description
_{Short Issue Description}_

### Checks
- [ ] Jira link attached: [VEGA-XYZ]()
- [ ] Possible Associated Jira links:
- [ ] Personal Vega Instance link attached: http://xx-yy-vega-builder.code013.org
- [ ] Jira tasks for technical debt were created (if needed)

### Type
- [ ] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [ ] Bug Fix
- [ ] Test
- [ ] Refactoring

### PR/MR Requirements
- [ ] PR/MR title meet requirements/convention
- [ ] Target branch is correct
- [ ] PR/MR branch was rebased at correct branch
- [ ] Diff was checked
- [ ] Configuration files were checked at test repositories
- [ ] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General
- [ ] Exploratory Tested at Personal Vega Instance
- [ ] Existing E2E Tests done, Screenshot attached
- [ ] Existing Integration Tests done, Screenshot attached, Jenkins link:
- [ ] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed
- [ ] New Integration Tests developed
- [ ] New Unit Tests developed
- [ ] API documentation was fully and correctly updated

### E2E Suite Jenkins link
_{link}_

### E2E Suite Screenshot
_{Screenshot}_

### Integration Tests Screenshot
_{Screenshot}_

### Unit Tests Screenshot
_{Screenshot}_
