### PR TITLE
fix(ci): add BASE_URL env parameter

### DIFF
--- a/ci/build-entrypoint.sh
+++ b/ci/build-entrypoint.sh
@@ -13,6 +13,12 @@ then
   exit 1;
 fi
 
+if [ -z "$BASE_URL" ]
+then
+  echo "BASE_URL is required to continue. Abort."
+  exit 1;
+fi
+
 if [ -z "$BASE_API_URL" ]
 then
   echo "BASE_API_URL is required to continue. Abort."

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -37,5 +37,6 @@ docker run \
   --env NPM_URI=$NPM_URI \
   --env NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN \
   --env BASE_API_URL=$BASE_API_URL \
+  --env BASE_URL=$BASE_URL \
   $TAG \
   /app/ci/build-entrypoint.sh


### PR DESCRIPTION
## Задача
Задача в Jira: https://jira.konakov.tv/browse/VEGA-3243
Jira issue: VEGA-3243

### Description
Для корректной загрузки shell необходимо прокинуть BASE_URL

### Checks
- [x] Jira link attached: [VEGA-3243]()
- [ ] Possible Associated Jira links:
- [ ] Personal Vega Instance link attached: http://xx-yy-vega-builder.code013.org
- [ ] Jira tasks for technical debt were created (if needed)

### Type
- [ ] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [ ] Bug Fix
- [ ] Test
- [ ] Refactoring

### PR/MR Requirements
- [ ] PR/MR title meet requirements/convention
- [ ] Target branch is correct
- [ ] PR/MR branch was rebased at correct branch
- [ ] Diff was checked
- [ ] Configuration files were checked at test repositories
- [ ] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General
- [ ] Exploratory Tested at Personal Vega Instance
- [ ] Existing E2E Tests done, Screenshot attached
- [ ] Existing Integration Tests done, Screenshot attached, Jenkins link:
- [ ] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed
- [ ] New Integration Tests developed
- [ ] New Unit Tests developed
- [ ] API documentation was fully and correctly updated

### E2E Suite Jenkins link
_{link}_

### E2E Suite Screenshot
_{Screenshot}_

### Integration Tests Screenshot
_{Screenshot}_

### Unit Tests Screenshot
_{Screenshot}_
